### PR TITLE
frontのトーナメントの描画を追加！

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,11 +9,15 @@
 <body class="bg-gray-100 text-gray-800 flex flex-col items-center min-h-screen">
     <header class="w-full bg-gray-800 text-white p-4 text-center shadow-md">
         <h1 class="text-2xl font-bold">My Pong Game</h1>
-        <nav class="mt-2">
+        <nav class="mt-4 flex justify-between items-center">
             <button class="mx-2 px-4 py-2 bg-gray-600 hover:bg-gray-700 rounded transition" onclick="router.navigateTo('/game')">Game</button>
             <button class="mx-2 px-4 py-2 bg-gray-600 hover:bg-gray-700 rounded transition" onclick="router.navigateTo('/win')">Win Screen</button>
             <button class="mx-2 px-4 py-2 bg-gray-600 hover:bg-gray-700 rounded transition" onclick="router.navigateTo('/lose')">Lose Screen</button>
             <button class="mx-2 px-4 py-2 bg-gray-600 hover:bg-gray-700 rounded transition" onclick="router.navigateTo('/error')">Error Screen</button>
+            <button class="mx-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded transition" onclick="router.navigateTo('/tournament/2/before')">2P (Before)</button>
+            <button class="mx-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded transition" onclick="router.navigateTo('/tournament/2/after')">2P (After)</button>
+            <button class="mx-2 px-4 py-2 bg-green-600 hover:bg-green-700 rounded transition" onclick="router.navigateTo('/tournament/3/before')">3P (Before)</button>
+            <button class="mx-2 px-4 py-2 bg-green-600 hover:bg-green-700 rounded transition" onclick="router.navigateTo('/tournament/3/after')">3P (After)</button>
         </nav>
     </header>
     <main class="flex-grow flex justify-center items-center w-full p-4">

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,55 +1,293 @@
-const MY_USERNAME = "kotaro";
-
-const gameState = {
-    type: "gameState",
-    state: { paddle1Y: 250, paddle2Y: 350, ballX: 130, ballY: 30, score1: 2, score2: 5 },
-};
-const gameEndState = {
-    type: "gameEND",
-    round: 1,
-    winner_score: 5, loser_score: 2,
-    winner: "yui", loser: "kotaro",
-    winner_image: "https://via.placeholder.com/150/4299E1/FFFFFF?Text=Yui",
-    loser_image: "https://via.placeholder.com/150/F56565/FFFFFF?Text=Kotaro",
+// ===== 仮のユーザーデータベース =====
+const userDatabase: { [key: string]: { name: string; image: string } } = {
+    "player-a-id": { name: "K.K.", image: "https://via.placeholder.com/150/FFC107/000000?Text=A" },
+    "player-b-id": { name: "Isabelle", image: "https://via.placeholder.com/150/03A9F4/FFFFFF?Text=B" },
+    "player-c-id": { name: "Tom Nook", image: "https://via.placeholder.com/150/4CAF50/FFFFFF?Text=C" },
 };
 
-class AppRouter {
-    private appElement: HTMLElement;
+  const MY_USERNAME = "enoch";
+  const MY_USER_ID = "player-a-id";
+  
+  // --- 2人用トーナメント ---
+  const tournament2P_before = {
+    id: "9fd411f6-3ee4-4fc2-9cef-0ee952dc236e", owner_id: "player-a-id", name: "2-Player Tournament (Before)", state: "open", champion_id: "",
+    participants: [
+      { id: "player-a-id", status: 'pending' },
+      { id: "player-b-id", status: 'pending' }
+    ], histories: []
+  };
+  const tournament2P_after = {
+    id: "9fd411f6-3ee4-4fc2-9cef-0ee952dc236e", name: "2-Player Tournament (After)", state: "close", champion_id: "player-b-id",
+    participants: ["player-a-id", "player-b-id"],
+    histories: [{
+      winner: { id: "player-b-id", score: 10 },
+      loser: { id: "player-a-id", score: 8 },
+    }]
+  };
+  
+  // --- 3人用トーナメント ---
+  const tournament3P_before = {
+    id: "031b1b96-4309-465d-915f-d43bdf22a955", owner_id: "player-a-id", name: "3-Player Tournament (Before)", state: "open", champion_id: "",
+    participants: [
+      { id: "player-a-id", status: 'pending' },
+      { id: "player-b-id", status: 'pending' },
+      { id: "player-c-id", status: 'pending' }
+    ], histories: []
+  };
+  const tournament3P_after = {
+      id: "031b1b96-4309-465d-915f-d43bdf22a955", name: "3-Player Tournament (After)", state: "close", champion_id: "player-b-id",
+      participants: ["player-a-id", "player-b-id", "player-c-id"],
+      histories: [
+          { winner: { id: "player-b-id", score: 10 }, loser: { id: "player-a-id", score: 5 } },
+          { winner: { id: "player-b-id", score: 10 }, loser: { id: "player-c-id", score: 7 } }
+      ]
+  };
+  
+  // --- 他の画面用のモックデータ ---
+  const gameState = { state: { paddle1Y: 250, paddle2Y: 350, ballX: 130, ballY: 30, score1: 2, score2: 5 } };
+  const gameEndState = { winner: "yui", loser: "kotaro", winner_score: 5, loser_score: 2, winner_image: "https://via.placeholder.com/150/0000FF/FFFFFF?Text=Yui", loser_image: "https://via.placeholder.com/150/FF0000/FFFFFF?Text=Kotaro" };
 
-    constructor() {
-        this.appElement = document.getElementById('app')!;
-        window.addEventListener('popstate', () => this.handleLocation());
-    }
 
-    public navigateTo(path: string) {
-        if (window.location.pathname === path) return;
-        history.pushState({}, '', path);
-        this.handleLocation();
-    }
+  // ===== アプリケーション本体 =====
+  class AppRouter {
+      private appElement: HTMLElement;
+      private currentTournamentData: any = null;
+  
+      constructor() {
+          this.appElement = document.getElementById('app')!;
+          window.addEventListener('popstate', () => this.handleLocation());
+      }
+  
+      public navigateTo(path: string) {
+          if (window.location.pathname === path) return;
+          history.pushState({}, '', path);
+          this.handleLocation();
+      }
+  
+      public async handleLocation() {
+          const path = window.location.pathname;
+  
+          if (path.startsWith('/tournament/')) {
+              const parts = path.split('/');
+              const participantCount = parseInt(parts[2]);
+              const state = parts[3] || 'before';
+  
+              let data;
+              if (participantCount === 2) {
+                  data = JSON.parse(JSON.stringify(state === 'before' ? tournament2P_before : tournament2P_after));
+              } else {
+                  data = JSON.parse(JSON.stringify(state === 'before' ? tournament3P_before : tournament3P_after));
+              }
+  
+              this.currentTournamentData = data;
+              this.renderTournamentScreen();
+  
+              if (state === 'before' && participantCount > 0) {
+                setTimeout(() => {
+                    alert('Readyボタンを押してください');
+                }, 100);
+              }
+          } else {
+              switch (path) {
+                  case '/game': this.renderGameScreen(); break;
+                  case '/win': this.renderResultScreen({ ...gameEndState, winner: MY_USERNAME, loser: 'opponent' }); break;
+                  case '/lose': this.renderResultScreen({ ...gameEndState, winner: 'opponent', loser: MY_USERNAME }); break;
+                  case '/error': this.renderErrorScreen(); break;
+                  default: this.navigateTo('/tournament/3/after'); break;
+              }
+          }
+      }
+  
+      public togglePlayerStatus(playerId: string) {
+          if (!this.currentTournamentData) return;
+          const player = this.currentTournamentData.participants.find((p: any) => p.id === playerId);
+          if (player) {
+              player.status = player.status === 'pending' ? 'ready' : 'pending';
+          }
+          this.renderTournamentScreen();
+          this.checkAllPlayersReady();
+      }
+  
+      private checkAllPlayersReady() {
+          if (!this.currentTournamentData || this.currentTournamentData.state !== 'open') return;
+          const allReady = this.currentTournamentData.participants.every((p: any) => p.status === 'ready');
+          if (allReady) {
+              setTimeout(() => {
+                  alert('まもなく試合が始まります！');
+              }, 100);
+          }
+      }
+  
+      private render(content: string) {
+          this.appElement.innerHTML = content;
+      }
 
-    public handleLocation() {
-        const path = window.location.pathname;
-        switch (path) {
-            case '/game':
-                this.renderGameScreen();
-                break;
-            case '/win':
-                this.renderResultScreen({ ...gameEndState, winner: MY_USERNAME, loser: 'opponent' });
-                break;
-            case '/lose':
-                this.renderResultScreen({ ...gameEndState, winner: 'opponent', loser: MY_USERNAME });
-                break;
-            case '/error':
-                this.renderErrorScreen();
-                break;
-            default:
-                this.navigateTo('/game');
-                break;
+    private renderTournamentScreen() {
+        if (!this.currentTournamentData) return;
+        const { name, participants: initialParticipants, histories, champion_id, state , owner_id} = this.currentTournamentData;
+
+        let contentHTML;
+
+    // =========================================================================
+    //  対戦前 (state: 'open') の場合の描画ロジック
+    // =========================================================================
+        if (state === 'open') {
+            const getPlayerHTML_interactive = (participant: any) => {
+                const { id, status } = participant;
+                const user = userDatabase[id] || { name: 'Unknown', image: '' };
+            
+                return `
+                    <div class="matchup !flex-row justify-between items-center">
+                        <div class="player">
+                            <img src="${user.image}" class="player-avatar">
+                            <span>${user.name}</span>
+                        </div>
+                        <div class="flex items-center gap-4 ml-auto">
+                            <span class="status ${status === 'ready' ? 'text-green-400' : 'text-red-400'}">
+                                ${status === 'ready' ? 'Ready' : 'Pending'}
+                            </span>
+                            <button class="px-3 py-1 text-sm bg-gray-500 hover:bg-gray-600 rounded" onclick="router.togglePlayerStatus('${id}')">
+                                Toggle
+                            </button>
+                        </div>
+                    </div>
+                `;
+            };
+            const participantsListHTML = initialParticipants.map(getPlayerHTML_interactive).join('');
+            // 1. 全員がReadyかチェック
+            const allPlayersReady = initialParticipants.every((p: any) => p.status === 'ready');
+            // 2. ログインユーザーがオーナーかチェック
+            const isOwner = MY_USER_ID === owner_id;
+
+            let startButtonHTML = '';
+            // 3. 全員Readyかつ、自分がオーナーの場合のみボタンを描画
+            if (allPlayersReady && isOwner) {
+                // 以前の「まもなく〜」のアラートは不要になったのでコメントアウト
+                // alert('まもなく試合が始まります！');
+                startButtonHTML = `
+                    <div class="mt-8 text-center animate-pulse">
+                        <button
+                            class="px-8 py-4 text-xl font-bold text-white bg-green-600 rounded-lg shadow-lg hover:bg-green-700 focus:outline-none focus:ring-4 focus:ring-green-300"
+                            onclick="router.startTournament()"
+                        >
+                            試合開始
+                        </button>
+                    </div>
+                `;
+            }
+            contentHTML = `
+                <div class="w-full max-w-md mx-auto">
+                    ${participantsListHTML}
+                    ${startButtonHTML}
+                </div>
+            `;
+    
+    // =========================================================================
+    //  対戦後 (state: 'close') の場合の描画ロジック
+    // =========================================================================
+        } else {
+        // ステップ1: 参加者リストを準備する (不戦勝 'Bye' の対応)
+            const numParticipants = initialParticipants.length;
+            let bracketSize = 2;
+            while (bracketSize < numParticipants) {
+                bracketSize *= 2;
+            }
+            const players = [...initialParticipants.map((p: any) => (typeof p === 'object' ? p.id : p))];
+            while (players.length < bracketSize) {
+                players.push(null); // 'null'を不戦勝(Bye)として扱う
+            }
+
+        // ステップ2: ラウンドと対戦の骨格を生成する
+            const rounds: any[] = [];
+            let currentRoundPlayers = [...players];
+            let roundIndex = 0;
+            while (currentRoundPlayers.length > 1) {
+                const round = { index: roundIndex, matches: [] as any[] };
+                for (let i = 0; i < currentRoundPlayers.length; i += 2) {
+                    round.matches.push({
+                        player1: currentRoundPlayers[i],
+                        player2: currentRoundPlayers[i + 1],
+                        winner: null, score1: null, score2: null,
+                    });
+                }
+                rounds.push(round);
+                currentRoundPlayers = new Array(currentRoundPlayers.length / 2).fill(null);
+                roundIndex++;
+            }
+        
+        // ステップ3: 対戦履歴を反映させ、勝者を進める
+            rounds.forEach((round, rIndex) => {
+                round.matches.forEach((match: any, mIndex: number) => {
+                    if (match.player1 && !match.player2) match.winner = match.player1;
+                    if (!match.player1 && match.player2) match.winner = match.player2;
+
+                    const history = histories.find((h: any) => 
+                        (h.winner.id === match.player1 && h.loser.id === match.player2) ||
+                        (h.winner.id === match.player2 && h.loser.id === match.player1)
+                    );
+
+                    if (history) {
+                        match.winner = history.winner.id;
+                        if (history.winner.id === match.player1) {
+                            match.score1 = history.winner.score;
+                            match.score2 = history.loser.score;
+                        } else {
+                            match.score1 = history.loser.score;
+                            match.score2 = history.winner.score;
+                        }
+                    }
+                
+                    if (match.winner && rounds[rIndex + 1]) {
+                        const nextMatchIndex = Math.floor(mIndex / 2);
+                        const playerSlot = mIndex % 2 === 0 ? 'player1' : 'player2';
+                        rounds[rIndex + 1].matches[nextMatchIndex][playerSlot] = match.winner;
+                    }
+                });
+            });
+
+        // ステップ4: HTMLをレンダリングする (トーナメント表用)
+            const getPlayerHTML_bracket = (playerId: string | null, score: number | null = null, isWinner = false) => {
+                if (!playerId) return `<div class="player text-gray-500">-- Bye --</div>`;
+                const user = userDatabase[playerId] || { name: 'Unknown', image: '' };
+                return `
+                    <div class="player ${isWinner ? 'font-bold text-yellow-300' : ''}">
+                        <img src="${user.image}" class="player-avatar">
+                        <span>${user.name}</span>
+                    </div>
+                    <div class="score ${isWinner ? 'font-bold text-yellow-300' : ''}">${score ?? ''}</div>
+                `;
+            };
+
+            const roundsHTML = rounds.map(round => `
+                <div class="round">
+                    ${round.matches.map((match: any) => `
+                        <div class="matchup">
+                            ${getPlayerHTML_bracket(match.player1, match.score1, match.winner === match.player1)}
+                            ${getPlayerHTML_bracket(match.player2, match.score2, match.winner === match.player2)}
+                        </div>
+                    `).join('')}
+                </div>
+            `).join('');
+
+            const championHTML = champion_id ? `
+                <div class="round">
+                    <div class="champion">
+                        <span class="text-yellow-400 text-2xl">🏆 CHAMPION 🏆</span>
+                        ${getPlayerHTML_bracket(champion_id, null, true)}
+                    </div>
+                </div>
+            ` : '';
+            
+            contentHTML = `<div class="tournament-bracket">${roundsHTML}${championHTML}</div>`;
         }
-    }
 
-    private render(content: string) {
-        this.appElement.innerHTML = content;
+    // 最終的なHTMLを描画
+        this.render(`
+            <div class="bg-gray-800 bg-opacity-80 p-6 rounded-lg text-white">
+                <h2 class="text-3xl font-bold text-center mb-6">${name}</h2>
+                ${contentHTML}
+            </div>
+        `);
     }
 
     // --- 各画面の描画メソッド（Tailwind CSS版） ---
@@ -71,7 +309,6 @@ class AppRouter {
     }
 
     private drawGame(ctx: CanvasRenderingContext2D, width: number, height: number) {
-        /* ... Canvasの描画ロジックは変更なし ... */
         const state = gameState.state;
         const paddleWidth = 100;
         const paddleHeight = 20;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -64,7 +64,7 @@ const userDatabase: { [key: string]: { name: string; image: string } } = {
           this.handleLocation();
       }
   
-      public async handleLocation() {
+      public handleLocation() {
           const path = window.location.pathname;
   
           if (path.startsWith('/tournament/')) {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -75,7 +75,7 @@ body {
     top: -21px; /* (margin-top - matchup-height) / 2 + matchup-height/2 - 1 */
     left: -25px;
     width: 25px;
-    height: 82px; /* matchup-height + margin-top */
+    height: calc(var(--matchup-height) + var(--margin-top)); /* matchup-height + margin-top */
     border: 2px solid #9ca3af; /* gray-400 */
     border-right: none;
     border-radius: 10px 0 0 10px;

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -3,18 +3,97 @@
 @tailwind utilities;
 
 body {
-  /* 背景画像へのパスを指定 */
-  background-image: url("/assets/background.jpeg");
+    /* 背景画像へのパスを指定 */
+    background-image: url('/assets/background.jpeg');
+    
+    /* 画面全体を覆うように表示 */
+    background-size: cover;
+  
+    /* 画像を中央に配置 */
+    background-position: center;
+  
+    /* 画像を繰り返さない */
+    background-repeat: no-repeat;
+    
+    /* スクロールしても背景を固定 */
+    background-attachment: fixed;
+}
 
-  /* 画面全体を覆うように表示 */
-  background-size: cover;
+/* トーナメント用のカスタムスタイル */
+.tournament-bracket {
+    display: flex;
+    justify-content: space-around;
+  }
+  .round {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+  }
+  .matchup {
+    background-color: rgba(0, 0, 0, 0.4);
+    margin: 20px 0;
+    border-radius: 8px;
+    padding: 10px;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  /* 試合の間のスペースを確保 */
+  .matchup + .matchup {
+      margin-top: 60px;
+  }
+  .player {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .player-avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+  }
+  .score {
+    margin-left: auto;
+    font-family: monospace;
+    font-size: 1.2rem;
+  }
+  
+  /* 勝ち上がり線の描画 */
+  .matchup::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    right: -25px; /* 親要素の幅と線の太さを考慮 */
+    width: 25px;
+    height: 2px;
+    background-color: #9ca3af; /* gray-400 */
+  }
+  .round + .round .matchup::before {
+    content: '';
+    position: absolute;
+    top: -21px; /* (margin-top - matchup-height) / 2 + matchup-height/2 - 1 */
+    left: -25px;
+    width: 25px;
+    height: 82px; /* matchup-height + margin-top */
+    border: 2px solid #9ca3af; /* gray-400 */
+    border-right: none;
+    border-radius: 10px 0 0 10px;
+  }
+  
+/* 最後のラウンドの線は不要 */
+.round:last-child > .matchup::after {
+    display: none;
+}
+.champion {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+}
 
-  /* 画像を中央に配置 */
-  background-position: center;
-
-  /* 画像を繰り返さない */
-  background-repeat: no-repeat;
-
-  /* スクロールしても背景を固定 */
-  background-attachment: fixed;
+.status {
+    font-weight: bold;
+    min-width: 60px; /* Pending/Readyの幅を揃える */
+    text-align: center;
 }


### PR DESCRIPTION
概要

ゲーム画面に続き、主要機能であるトーナメント画面を実装しました。
対戦前の準備画面と、対戦後の結果表示（トーナメント表）の両方に対応しています。ロジックは様々な人数に対応できるよう汎用的に設計されていますが、今回は2人および3人用のトーナメントに対応しています。

主な変更点・追加機能

トーナメント画面の追加

対戦前（state: 'open'）と対戦後（state: 'close'）の2つの状態に対応した画面描画を実装。

対戦前の準備画面（インタラクティブ機能）

参加者リストと各プレイヤーのステータス（Pending / Ready）を表示。

各プレイヤーが「Toggle」ボタンで自身のステータスを切り替え可能。

トーナメントのオーナーにのみ表示される「試合開始」ボタンを実装（まだオーナーの画面は未実装）

全プレイヤーが「Ready」になるまで「試合開始」ボタンは表示されない。

オーナーがボタンを押すと、試合開始を告げるアラートが表示される。

対戦後の結果画面（トーナメント表）

for文（ループ）を使用した汎用的なトーナメント表の描画ロジックを実装。
また、mapなども利用し、プレイヤーの同一処理を簡潔にしました。（当たり前です...）

参加人数に応じて、不戦勝（Bye）を自動的に計算・表示。（全体の参加人数が、次の２のn乗になるように設定）

対戦履歴（histories）を元に、スコアと勝者を反映。

最終的なチャンピオンをハイライト表示。

その他

main.tsに2人・3人用のトーナメントデータを追加。

index.htmlに動作確認用のナビゲーションボタンを追加。

style.cssにトーナメント表用のカスタムスタイル（対戦カード間の接続線など）を追加。（tailwind CSSだけでは表現するのが厄介な部分などを普通に追加）

動作確認の方法 🧪

npm run dev と npm start を実行。

ヘッダーに追加された「2P (Before)」「3P (Before)」ボタンをクリック。

対戦準備画面が表示され、各プレイヤーの「Toggle」ボタンでステータスが切り替わることを確認してください。

すべてのプレイヤーを「Ready」にすると、オーナー（現在はplayer-a-idに固定）にのみ「試合開始」ボタンが表示されることを確認してください。

「試合開始」ボタンをクリックし、アラートが表示されることを確認してください。

ヘッダーの「2P (After)」「3P (After)」ボタンをクリックし、それぞれの人数に応じたトーナメント表が正しく描画されることを確認してください。