### PR TITLE
Front add deatil tournament

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,6 +14,7 @@
             <button class="menu-item" onclick="window.router.navigateTo('/tournaments')">Tournaments</button>
             <button class="menu-item" onclick="window.router.navigateTo('/matchmaking')">Matchmaking</button>
             <button class="menu-item bg-red-600 hover:bg-red-700" onclick="window.router.navigateTo('/tournament/admin/a7b7a8a0-c5e3-4b1d-8f6a-9f0b1c2d3e4f')">Admin</button>
+            <button class="menu-item" onclick="window.router.navigateTo('/signup')">Signup</button>
         </nav>
     </header>
     <main class="flex-grow flex justify-center items-center w-full p-4">

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -3,3 +3,5 @@ export const TOURNAMENT_URL = 'http://localhost:8080';
 
 // gameサービスのベースURL
 export const GAME_URL = 'http://localhost:4000';
+
+export const SERVERURL = 'http://localhost:8000';

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -2,54 +2,77 @@ import * as api from './services/api';
 import * as gameViews from './views/gameViews';
 import * as tournamentViews from './views/tournamentView';
 import * as matchmakingView from './views/matchmakingView';
-
-const MY_USER_ID = "player-a-id"; 
+import * as authView from './views/authView';
+import { getUserId } from './services/auth';
 
 export class AppRouter {
     private appElement: HTMLElement;
-    // private userDatabase: any = {};
-    private userDatabase: any = {
-        "player-a-id": { name: "K.K.", image: "https://via.placeholder.com/150/FFC107/000000?Text=A" },
-        "player-b-id": { name: "Isabelle", image: "https://via.placeholder.com/150/03A9F4/FFFFFF?Text=B" },
-        "player-c-id": { name: "Tom Nook", image: "https://via.placeholder.com/150/4CAF50/FFFFFF?Text=C" },
-    };
+    private userDatabase: any = {}; // ユーザー情報をここにキャッシュ
     private currentTournamentData: any = null;
 
     constructor() {
         this.appElement = document.getElementById('app')!;
         window.addEventListener('popstate', () => this.handleLocation());
     }
+    
+    /**
+     * アプリケーションの初期化処理
+     * 最初に必要なグローバルデータ（ユーザー情報など）をAPIから取得する
+     */
+    public async init() {
+        try {
+            // 最初にユーザー情報を取得してキャッシュに保存
+            // this.userDatabase = await api.getUsers();
+            // 上記APIがまだないため、仮のデータを設定
+            this.userDatabase = {
+                "player-a-id": { name: "K.K.", image: "https://via.placeholder.com/150/FFC107/000000?Text=A" },
+                "player-b-id": { name: "Isabelle", image: "https://via.placeholder.com/150/03A9F4/FFFFFF?Text=B" },
+                "player-c-id": { name: "Tom Nook", image: "https://via.placeholder.com/150/4CAF50/FFFFFF?Text=C" },
+            };
+        } catch (error) {
+            console.error("Failed to initialize app with user data:", error);
+        }
+        // データの準備ができてから最初の画面描画を実行
+        this.handleLocation();
+    }
 
+    /**
+     * 指定されたパスに画面を遷移させる
+     */
     public navigateTo(path: string) {
         if (window.location.pathname === path) return;
         history.pushState({}, '', path);
         this.handleLocation();
     }
 
+    /**
+     * 現在のURLに基づいて、適切な画面を描画する
+     */
     public async handleLocation() {
         const path = window.location.pathname;
         try {
-            if (path === '/tournaments') {
+            if (path === '/tournaments/new') {
+                tournamentViews.renderCreateTournamentScreen(this.appElement);
+            } else if (path === '/tournaments') {
                 const tournaments = await api.getTournaments();
-                tournamentViews.renderTournamentListScreen(this.appElement, tournaments, MY_USER_ID, this.userDatabase);
-
+                const myUserId = getUserId();
+                tournamentViews.renderTournamentListScreen(this.appElement, tournaments, myUserId, this.userDatabase);
             } else if (path.startsWith('/tournament/detail/')) {
                 const tournamentId = path.split('/')[3];
                 const tournamentData = await api.getTournamentById(tournamentId);
                 this.currentTournamentData = tournamentData;
-                tournamentViews.renderTournamentScreen(this.appElement, this.currentTournamentData, this.userDatabase, MY_USER_ID);
-
+                tournamentViews.renderTournamentScreen(this.appElement, this.currentTournamentData, this.userDatabase, getUserId());
             } else if (path.startsWith('/tournament/admin/')) {
                 const tournamentId = path.split('/')[3];
-                if (!tournamentId) {
-                    this.navigateTo('/tournaments');
-                    return;
-                }
+                if (!tournamentId) { this.navigateTo('/tournaments'); return; }
                 const tournamentData = await api.getTournamentById(tournamentId);
                 this.currentTournamentData = tournamentData;
-                tournamentViews.renderAdminScreen(this.appElement, this.currentTournamentData, MY_USER_ID);
+                tournamentViews.renderAdminScreen(this.appElement, this.currentTournamentData, getUserId());
             } else {
                 switch (path) {
+                    case '/signup':
+                        authView.renderSignupScreen(this.appElement);
+                        break;
                     case '/matchmaking':
                         matchmakingView.renderMatchmakingScreen(this.appElement);
                         break;
@@ -76,6 +99,8 @@ export class AppRouter {
         }
     }
 
+    // --- インタラクティブな操作を処理するメソッド群 ---
+
     public async callFindMatch() {
         const responseDisplay = document.getElementById('response-data');
         if (!responseDisplay) return;
@@ -88,36 +113,64 @@ export class AppRouter {
         }
     }
 
-    public togglePlayerStatus(playerId: string) {
-        if (!this.currentTournamentData) return;
-        const player = this.currentTournamentData.participants.find((p: any) => p.id === playerId);
-        if (player) {
-            player.status = player.status === 'pending' ? 'ready' : 'pending';
-        }
-        tournamentViews.renderTournamentScreen(this.appElement, this.currentTournamentData, this.userDatabase, MY_USER_ID);
-    }
-    
-    public startTournament() {
-        alert('トーナメントが始まります！');
-    }
-
-    public async handleAdminFormSubmit(event: SubmitEvent) {
+    public async handleSignup(event: SubmitEvent) {
         event.preventDefault();
-        if (!this.currentTournamentData) return;
-
         const formData = new FormData(event.target as HTMLFormElement);
-        const dataToUpdate = {
-            name: formData.get('name') as string,
-            description: formData.get('description') as string,
-            max_participants: parseInt(formData.get('max_participants') as string, 10),
-        };
+        const name = formData.get('name') as string;
+
+        if (!name) {
+            alert('名前を入力してください。');
+            return;
+        }
 
         try {
-            this.currentTournamentData = await api.updateTournament(this.currentTournamentData.id, dataToUpdate);
-            alert('トーナメント情報を更新しました！');
-            tournamentViews.renderAdminScreen(this.appElement, this.currentTournamentData, MY_USER_ID);
+            const data = await api.signup(name);
+            alert(`ようこそ、${data.name}さん！ユーザーが作成されました。`);
+            // サインアップ成功後、トーナメント一覧へ遷移
+            this.navigateTo('/tournaments');
         } catch (error) {
-            alert('情報の更新に失敗しました。');
+            alert('サインアップに失敗しました。ユーザー名が既に使用されている可能性があります。');
+        }
+    }
+    
+    public async handleCreateTournament(event: SubmitEvent) {
+        event.preventDefault();
+        const formData = new FormData(event.target as HTMLFormElement);
+        const data = {
+            name: formData.get('name') as string,
+            description: formData.get('description') as string
+        };
+        try {
+            const newTournament = await api.createTournament(data);
+            alert('トーナメントを作成しました！');
+            this.navigateTo(`/tournament/detail/${newTournament.id}`);
+        } catch (error) {
+            alert('トーナメントの作成に失敗しました。');
+        }
+    }
+
+    public async handleJoinTournament(tournamentId: string) {
+        const myUserId = getUserId();
+        if (!myUserId) { alert("サインアップまたはログインが必要です。"); return; }
+        try {
+            await api.joinTournament(tournamentId, myUserId);
+            alert('トーナメントに参加しました！');
+            this.handleLocation(); // 画面を再読み込みして参加者リストを更新
+        } catch (error) {
+            alert('参加に失敗しました。');
+        }
+    }
+
+    public async handleSetReady(tournamentId: string, participantId: string, currentStatus: string) {
+        try {
+            if (currentStatus === 'pending' || currentStatus === 'accepted') {
+                await api.setParticipantReady(tournamentId, participantId);
+            } else {
+                await api.setParticipantCancel(tournamentId, participantId);
+            }
+            this.handleLocation(); // 画面を再読み込みしてステータスを更新
+        } catch (error) {
+            alert('ステータスの変更に失敗しました。');
         }
     }
 
@@ -127,7 +180,7 @@ export class AppRouter {
             try {
                 this.currentTournamentData = await api.openTournament(this.currentTournamentData.id);
                 alert('トーナメントがオープンされました！');
-                tournamentViews.renderAdminScreen(this.appElement, this.currentTournamentData, MY_USER_ID);
+                tournamentViews.renderAdminScreen(this.appElement, this.currentTournamentData, getUserId());
             } catch (error) {
                 alert('トーナメントの開始に失敗しました。');
             }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,12 +1,36 @@
-import { TOURNAMENT_URL, GAME_URL } from '../config';
+import { TOURNAMENT_URL, GAME_URL, SERVERURL } from '../config';
+import { getAuthHeaders, saveUserId } from './auth';
 
-const AUTH_TOKEN = "your-secret-auth-token-here"; 
+export async function signup(name: string) {
+    try {
+        // バックエンドのAuthサービスのエンドポイントを叩く
+        const response = await fetch(`${SERVERURL}/auth/signup`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name }),
+        });
 
-const tournamentApiHeaders = {
-    'Content-Type': 'application/json',
-    'Authorization': `Bearer ${AUTH_TOKEN}`
-};
+        if (!response.ok) {
+            // エラーレスポンスもJSON形式の可能性があるため、内容を読み取る
+            const errorData = await response.json().catch(() => ({}));
+            throw new Error(`HTTP error! status: ${response.status}, message: ${errorData.error || 'Unknown error'}`);
+        }
+        
+        const data = await response.json();
+        if (data.id) {
+            // 成功レスポンスにIDが含まれていれば、localStorageに保存
+            saveUserId(data.id);
+        }
+        return data;
+    } catch (error) {
+        console.error("Signup failed:", error);
+        throw error;
+    }
+}
 
+/**
+ * マッチメイキングキューに参加する
+ */
 export async function findMatch() {
     try {
         const response = await fetch(`${GAME_URL}/ready`, {
@@ -22,57 +46,135 @@ export async function findMatch() {
     }
 }
 
+/**
+ * トーナメント一覧を取得する (GET /tournaments)
+ */
 export async function getTournaments() {
-    try {
-        const response = await fetch(`${TOURNAMENT_URL}/tournaments`, { 
-            headers: tournamentApiHeaders 
-        });
-        if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
-        return await response.json();
-    } catch (error) {
-        console.error("Failed to fetch tournaments:", error);
-        throw error;
-    }
+    const response = await fetch(`${TOURNAMENT_URL}/tournaments`, { headers: getAuthHeaders() });
+    if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+    return await response.json();
 }
 
+/**
+ * 新しいトーナメントを作成する (POST /tournaments)
+ */
+export async function createTournament(data: { name: string, description: string }) {
+    const response = await fetch(`${TOURNAMENT_URL}/tournaments`, {
+        method: 'POST',
+        headers: getAuthHeaders(),
+        body: JSON.stringify(data),
+    });
+    if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+    return await response.json();
+}
+
+/**
+ * 特定のトーナメント詳細を取得する (GET /tournaments/{id})
+ */
 export async function getTournamentById(id: string) {
-    try {
-        const response = await fetch(`${TOURNAMENT_URL}/tournaments/${id}`, { 
-            headers: tournamentApiHeaders 
-        });
-        if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
-        return await response.json();
-    } catch (error) {
-        console.error(`Failed to fetch tournament with id ${id}:`, error);
-        throw error;
-    }
+    const response = await fetch(`${TOURNAMENT_URL}/tournaments/${id}`, { headers: getAuthHeaders() });
+    if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+    return await response.json();
 }
 
+/**
+ * トーナメントを開始（オープン）状態にする (PUT /tournaments/{id}/open)
+ */
 export async function openTournament(id: string) {
-    try {
-        const response = await fetch(`${TOURNAMENT_URL}/tournaments/${id}/open`, {
-            method: 'PUT',
-            headers: tournamentApiHeaders,
-        });
-        if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
-        return await response.json();
-    } catch (error) {
-        console.error(`Failed to open tournament with id ${id}:`, error);
-        throw error;
-    }
+    const response = await fetch(`${TOURNAMENT_URL}/tournaments/${id}/open`, {
+        method: 'PUT',
+        headers: getAuthHeaders(),
+    });
+    if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+    return await response.json();
 }
 
-export async function updateTournament(id: string, data: { name: string; description: string; max_participants: number; }) {
-    try {
-        const response = await fetch(`${TOURNAMENT_URL}/tournaments/${id}`, {
-            method: 'PUT',
-            headers: tournamentApiHeaders,
-            body: JSON.stringify(data),
-        });
-        if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
-        return await response.json();
-    } catch (error) {
-        console.error(`Failed to update tournament with id ${id}:`, error);
-        throw error;
-    }
+/**
+ * トーナメントに参加者を追加する (POST /tournaments/{id}/participants)
+ */
+export async function joinTournament(tournamentId: string, userId: string) {
+    const response = await fetch(`${TOURNAMENT_URL}/tournaments/${tournamentId}/participants`, {
+        method: 'POST',
+        headers: getAuthHeaders(),
+        body: JSON.stringify({ userId }), // APIの仕様に合わせて body を調整
+    });
+    if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+    return await response.json();
 }
+
+/**
+ * 参加者のステータスを 'ready' にする
+ */
+export async function setParticipantReady(tournamentId: string, participantId: string) {
+    const response = await fetch(`${TOURNAMENT_URL}/tournaments/${tournamentId}/participants/${participantId}/ready`, {
+        method: 'PUT',
+        headers: getAuthHeaders(),
+    });
+    if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+    return await response.json();
+}
+
+/**
+ * 参加者のステータスを 'pending' (キャンセル) にする
+ */
+export async function setParticipantCancel(tournamentId: string, participantId: string) {
+    const response = await fetch(`${TOURNAMENT_URL}/tournaments/${tournamentId}/participants/${participantId}/cancel`, {
+        method: 'PUT',
+        headers: getAuthHeaders(),
+    });
+    if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+    return await response.json();
+}
+
+/**
+ * 対戦結果を作成（報告）する (POST /tournaments/{id}/histories)
+ */
+export async function createHistory(tournamentId: string, battleResult: any) {
+    const response = await fetch(`${TOURNAMENT_URL}/tournaments/${tournamentId}/histories`, {
+        method: 'POST',
+        headers: getAuthHeaders(),
+        body: JSON.stringify(battleResult),
+    });
+    if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+    return await response.json();
+}
+
+/**
+ * バトルを開始する (PUT /tournaments/{id}/battle/start)
+ */
+export async function startBattle(tournamentId: string) {
+    const response = await fetch(`${TOURNAMENT_URL}/tournaments/${tournamentId}/battle/start`, {
+        method: 'PUT',
+        headers: getAuthHeaders(),
+    });
+    if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+    return await response.json();
+}
+
+/**
+ * 対戦を終了する (POST /tournaments/{id}/battle/end)
+ */
+export async function endBattle(tournamentId: string, result: any) {
+    const response = await fetch(`${TOURNAMENT_URL}/tournaments/${tournamentId}/battle/end`, {
+        method: 'POST',
+        headers: getAuthHeaders(),
+        body: JSON.stringify(result),
+    });
+    if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+    return await response.json();
+}
+
+// export async function updateTournament(id: string, data: { name: string; description: string; max_participants: number; }) {
+//     try {
+//         const response = await fetch(`${TOURNAMENT_URL}/tournaments/${id}`, {
+//             method: 'PUT',
+//             headers: getAuthHeaders(),
+//             body: JSON.stringify(data),
+//         });
+//         if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+//         return await response.json();
+//     } catch (error) {
+//         console.error(`Failed to update tournament with id ${id}:`, error);
+//         throw error;
+//     }
+// }

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -1,0 +1,36 @@
+const USER_ID_KEY = 'user_id';
+
+/**
+ * ユーザーIDをlocalStorageに保存する
+ * @param id 保存するユーザーID
+ */
+export function saveUserId(id: string): void {
+    localStorage.setItem(USER_ID_KEY, id);
+    console.log(`User ID saved: ${id}`);
+}
+
+/**
+ * localStorageからユーザーIDを取得する
+ * @returns ユーザーID、または存在しない場合はnull
+ */
+export function getUserId(): string | null {
+    return localStorage.getItem(USER_ID_KEY);
+}
+
+/**
+ * 認証ヘッダーを含むヘッダーオブジェクトを生成する
+ * @returns HeadersInitオブジェクト
+ */
+export function getAuthHeaders(): HeadersInit {
+    const headers: HeadersInit = {
+        'Content-Type': 'application/json',
+    };
+
+    const userId = getUserId();
+    if (userId) {
+        // バックエンドが期待するヘッダー形式に合わせる。
+        // ここでは仮に 'Authorization': 'Bearer <user_id>' とする。
+        headers['Authorization'] = `Bearer ${userId}`;
+    }
+    return headers;
+}

--- a/frontend/src/views/authView.ts
+++ b/frontend/src/views/authView.ts
@@ -1,0 +1,21 @@
+function render(appElement: HTMLElement, content: string) {
+    appElement.innerHTML = content;
+}
+
+export function renderSignupScreen(appElement: HTMLElement) {
+    const content = `
+        <div class="bg-gray-800 bg-opacity-80 p-8 rounded-lg text-white max-w-md mx-auto">
+            <h2 class="text-3xl font-bold text-center mb-6">Sign Up</h2>
+            <form onsubmit="window.router.handleSignup(event)">
+                <div class="mb-4">
+                    <label for="signup-name" class="block text-sm font-medium text-gray-300 mb-1">User Name</label>
+                    <input type="text" id="signup-name" name="name" required class="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                </div>
+                <button type="submit" class="w-full px-4 py-2 bg-green-600 hover:bg-green-700 rounded text-white font-bold">
+                    Create User & Sign In
+                </button>
+            </form>
+        </div>
+    `;
+    render(appElement, content);
+}

--- a/frontend/src/views/tournamentView.ts
+++ b/frontend/src/views/tournamentView.ts
@@ -1,10 +1,40 @@
-function render(appElement: HTMLElement, content: string) {
+function render(appElement: HTMLElement, content: string): void {
     appElement.innerHTML = content;
 }
 
-export function renderTournamentListScreen(appElement: HTMLElement, tournaments: any[], MY_USER_ID: string, userDatabase: any) {
+/**
+ * 新しいトーナメントを作成するための画面を描画する
+ */
+export function renderCreateTournamentScreen(appElement: HTMLElement): void {
+    const contentHTML = `
+        <div class="bg-gray-800 bg-opacity-80 p-8 rounded-lg text-white w-full max-w-lg mx-auto">
+            <h2 class="text-3xl font-bold text-center mb-6">Create New Tournament</h2>
+            <form onsubmit="window.router.handleCreateTournament(event)">
+                <div class="mb-4">
+                    <label for="name" class="block text-sm font-medium text-gray-300 mb-1">Tournament Name</label>
+                    <input type="text" id="name" name="name" required class="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                </div>
+                <div class="mb-6">
+                    <label for="description" class="block text-sm font-medium text-gray-300 mb-1">Description</label>
+                    <textarea id="description" name="description" rows="4" class="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"></textarea>
+                </div>
+                <button type="submit" class="w-full px-4 py-2 bg-green-600 hover:bg-green-700 rounded text-white font-bold">
+                    作成する
+                </button>
+            </form>
+        </div>
+    `;
+    render(appElement, contentHTML);
+}
+
+
+/**
+ * トーナメント一覧画面を描画する
+ */
+export function renderTournamentListScreen(appElement: HTMLElement, tournaments: any[], myUserId: string | null, userDatabase: any): void {
     const listHTML = tournaments.map(t => {
-        const adminButtonHTML = t.owner_id === MY_USER_ID ?
+        // 自分がオーナーのトーナメントにだけ「管理」ボタンを表示する
+        const adminButtonHTML = t.owner_id === myUserId ?
             `<button class="mt-2 block w-full px-4 py-2 bg-red-600 hover:bg-red-700 rounded text-white font-semibold text-sm" onclick="window.router.navigateTo('/tournament/admin/${t.id}')">
                 管理する
             </button>` : '';
@@ -15,7 +45,7 @@ export function renderTournamentListScreen(appElement: HTMLElement, tournaments:
                     <h3 class="text-xl font-bold text-white">${t.name}</h3>
                     <p class="text-gray-400">${t.description}</p>
                 </div>
-                <div class="text-right">
+                <div class="text-right w-32 flex-shrink-0">
                     <span class="text-sm font-semibold px-3 py-1 rounded-full ${
                         t.state === 'open' ? 'bg-green-500 text-white' :
                         t.state === 'reception' ? 'bg-yellow-500 text-black' :
@@ -32,134 +62,93 @@ export function renderTournamentListScreen(appElement: HTMLElement, tournaments:
 
     const contentHTML = `
         <div class="bg-gray-800 bg-opacity-80 p-8 rounded-lg text-white w-full max-w-3xl mx-auto">
-            <h2 class="text-3xl font-bold text-center mb-8">Tournament List</h2>
+            <div class="flex justify-between items-center mb-8">
+                <h2 class="text-3xl font-bold">Tournament List</h2>
+                <button class="px-4 py-2 bg-green-600 hover:bg-green-700 rounded text-white font-semibold" onclick="window.router.navigateTo('/tournaments/new')">
+                    新規作成
+                </button>
+            </div>
             ${listHTML}
         </div>
     `;
     render(appElement, contentHTML);
 }
 
-export function renderTournamentScreen(appElement: HTMLElement, tournamentData: any, userDatabase: any, MY_USER_ID: string) {
+/**
+ * トーナメント詳細画面を描画する
+ */
+export function renderTournamentScreen(appElement: HTMLElement, tournamentData: any, userDatabase: any, myUserId: string | null): void {
     if (!tournamentData) {
         render(appElement, `<p class="text-red-500">Tournament data not found.</p>`);
         return;
     }
-
-    const { name, participants: initialParticipants, histories, champion_id, state, owner_id } = tournamentData;
+    const { name, participants, histories, champion_id, state, owner_id } = tournamentData;
     let contentHTML;
 
     switch(state) {
         case 'reception': {
-            const participantsList = initialParticipants.map((p: any) => {
-                const user = userDatabase[p.id] || { name: 'Unknown User', image: '' };
-                return `<li class="flex items-center gap-4 py-2 px-4 bg-gray-700 rounded mb-2"><img src="${user.image}" class="player-avatar"><span>${user.name}</span></li>`;
+            const isParticipant = participants.some((p: any) => p.userId === myUserId);
+            const joinButtonHTML = !isParticipant ? `<button class="mt-6 px-6 py-2 bg-blue-600 hover:bg-blue-700 rounded text-white" onclick="window.router.handleJoinTournament('${tournamentData.id}')">トーナメントに参加する</button>` : `<p class="mt-6 text-green-400">あなたは既に参加しています。</p>`;
+            const participantsList = participants.map((p: any) => {
+                const user = userDatabase[p.userId] || { name: 'Unknown User', image: '' };
+                return `<li class="flex items-center gap-4 py-2 px-4 bg-gray-700 rounded mb-2"><img src="${user.image || ''}" class="player-avatar"><span>${user.name}</span></li>`;
             }).join('');
-            contentHTML = `
-                <div class="text-center">
-                    <p class="text-yellow-400 mb-4">オーナーがトーナメントを開始するのを待っています...</p>
-                    <h4 class="text-lg font-bold mb-2">現在の参加者 (${initialParticipants.length}人)</h4>
-                    <ul class="text-left max-w-xs mx-auto">${participantsList}</ul>
-                </div>`;
+            contentHTML = `<div class="text-center"><p class="text-yellow-400 mb-4">オーナーがトーナメントを開始するのを待っています...</p><h4 class="text-lg font-bold mb-2">現在の参加者 (${participants.length}人)</h4><ul class="text-left max-w-xs mx-auto">${participantsList}</ul>${joinButtonHTML}</div>`;
             break;
         }
-
         case 'open': {
-            const getPlayerHTML_interactive = (participant: any) => {
-                const { id, status } = participant;
-                const user = userDatabase[id] || { name: 'Unknown', image: '' };
-                return `<div class="matchup !flex-row justify-between items-center"><div class="player"><img src="${user.image}" class="player-avatar"><span>${user.name}</span></div><div class="flex items-center gap-4 ml-auto"><span class="status ${status === 'ready' ? 'text-green-400' : 'text-red-400'}">${status === 'ready' ? 'Ready' : 'Pending'}</span><button class="px-3 py-1 text-sm bg-gray-500 hover:bg-gray-600 rounded" onclick="window.router.togglePlayerStatus('${id}')">Toggle</button></div></div>`;
+            const getPlayerHTML = (participant: any) => {
+                const user = userDatabase[participant.userId] || { name: 'Unknown', image: '' };
+                const isLoser = participant.state === 'lose';
+                const button = !isLoser ? `<button class="px-3 py-1 text-sm bg-gray-500 hover:bg-gray-600 rounded" onclick="window.router.handleSetReady('${tournamentData.id}', '${participant.id}', '${participant.state}')">Toggle Ready</button>` : '<span class="text-red-500 font-semibold">敗退</span>';
+                return `<div class="matchup !flex-row justify-between items-center"><div class="player"><img src="${user.image || ''}" class="player-avatar"><span>${user.name}</span></div><div class="flex items-center gap-4 ml-auto"><span class="status ${participant.state === 'ready' ? 'text-green-400' : 'text-yellow-400'}">${participant.state}</span>${button}</div></div>`;
             };
-            const participantsListHTML = initialParticipants.map(getPlayerHTML_interactive).join('');
-            const allPlayersReady = initialParticipants.every((p: any) => p.status === 'ready');
-            const isOwner = MY_USER_ID === owner_id;
+            const participantsListHTML = participants.map(getPlayerHTML).join('');
+            const allPlayersReady = participants.every((p: any) => p.state === 'ready' || p.state === 'lose');
+            const isOwner = myUserId === owner_id;
             let startButtonHTML = '';
             if (allPlayersReady && isOwner) {
-                startButtonHTML = `<div class="mt-8 text-center animate-pulse"><button class="px-8 py-4 text-xl font-bold text-white bg-green-600 rounded-lg shadow-lg hover:bg-green-700" onclick="window.router.startTournament()">試合開始</button></div>`;
+                startButtonHTML = `<div class="mt-8 text-center animate-pulse"><button class="px-8 py-4 text-xl font-bold text-white bg-green-600 rounded-lg shadow-lg hover:bg-green-700" onclick="window.router.startBattle('${tournamentData.id}')">次の対戦を開始</button></div>`;
             }
             contentHTML = `<div class="w-full max-w-md mx-auto">${participantsListHTML}${startButtonHTML}</div>`;
             break;
         }
-
+        case 'in_progress': {
+             const battlers = participants.filter((p: any) => p.state === 'in_progress');
+             const waiters = participants.filter((p: any) => p.state !== 'in_progress' && p.state !== 'lose');
+             const battlersHTML = battlers.map((p: any) => `<li>${userDatabase[p.userId]?.name}</li>`).join('');
+             const waitersHTML = waiters.map((p: any) => `<li>${userDatabase[p.userId]?.name}</li>`).join('');
+             contentHTML = `<div class="flex justify-around"><div class="w-1/2 p-4"><h3>待機者</h3><ul>${waitersHTML}</ul></div><div class="w-1/2 p-4 border-l border-gray-600"><h3>対戦中</h3><ul>${battlersHTML}</ul></div></div>`;
+             break;
+        }
         case 'close': {
-            const numParticipants = initialParticipants.length;
-            let bracketSize = 2;
-            while (bracketSize < numParticipants) { bracketSize *= 2; }
-            const players = [...initialParticipants.map((p: any) => (typeof p === 'object' ? p.id : p))];
-            while (players.length < bracketSize) { players.push(null); }
-            const rounds: any[] = [];
-            let currentRoundPlayers = [...players];
-            while (currentRoundPlayers.length > 1) {
-                const round = { matches: [] as any[] };
-                for (let i = 0; i < currentRoundPlayers.length; i += 2) {
-                    round.matches.push({ player1: currentRoundPlayers[i], player2: currentRoundPlayers[i + 1], winner: null, score1: null, score2: null });
-                }
-                rounds.push(round);
-                currentRoundPlayers = new Array(currentRoundPlayers.length / 2).fill(null);
-            }
-            rounds.forEach((round, rIndex) => {
-                round.matches.forEach((match: any, mIndex: number) => {
-                    if (match.player1 && !match.player2) match.winner = match.player1;
-                    if (!match.player1 && match.player2) match.winner = match.player2;
-                    const history = histories.find((h: any) => (h.winner.id === match.player1 && h.loser.id === match.player2) || (h.winner.id === match.player2 && h.loser.id === match.player1));
-                    if (history) {
-                        match.winner = history.winner.id;
-                        if (history.winner.id === match.player1) {
-                            match.score1 = history.winner.score; match.score2 = history.loser.score;
-                        } else {
-                            match.score1 = history.loser.score; match.score2 = history.winner.score;
-                        }
-                    }
-                    if (match.winner && rounds[rIndex + 1]) {
-                        const nextMatchIndex = Math.floor(mIndex / 2);
-                        const playerSlot = mIndex % 2 === 0 ? 'player1' : 'player2';
-                        rounds[rIndex + 1].matches[nextMatchIndex][playerSlot] = match.winner;
-                    }
-                });
-            });
-            const getPlayerHTML_bracket = (playerId: string | null, score: number | null = null, isWinner = false) => {
-                if (!playerId) return `<div class="player text-gray-500">-- Bye --</div>`;
-                const user = userDatabase[playerId] || { name: 'Unknown', image: '' };
-                return `<div class="player ${isWinner ? 'font-bold text-yellow-300' : ''}"><img src="${user.image}" class="player-avatar"><span>${user.name}</span></div><div class="score ${isWinner ? 'font-bold text-yellow-300' : ''}">${score ?? ''}</div>`;
-            };
-            const roundsHTML = rounds.map(round => `<div class="round">${round.matches.map((match: any) => `<div class="matchup">${getPlayerHTML_bracket(match.player1, match.score1, match.winner === match.player1)}${getPlayerHTML_bracket(match.player2, match.score2, match.winner === match.player2)}</div>`).join('')}</div>`).join('');
-            const championHTML = champion_id ? `<div class="round"><div class="champion"><span class="text-yellow-400 text-2xl">🏆 CHAMPION 🏆</span>${getPlayerHTML_bracket(champion_id, null, true)}</div></div>` : '';
-            contentHTML = `<div class="tournament-bracket">${roundsHTML}${championHTML}</div>`;
+            contentHTML = `<div class="text-center">トーナメントは終了しました。チャンピオン: ${userDatabase[champion_id]?.name || '不明'}</div>`;
             break;
         }
     }
-
-    const finalHTML = `
-        <div class="bg-gray-800 bg-opacity-80 p-6 rounded-lg text-white">
-            <h2 class="text-3xl font-bold text-center mb-6">${name}</h2>
-            ${contentHTML}
-        </div>
-    `;
+    const finalHTML = `<div class="bg-gray-800 bg-opacity-80 p-6 rounded-lg text-white"><h2 class="text-3xl font-bold text-center mb-6">${name}</h2>${contentHTML}</div>`;
     render(appElement, finalHTML);
 }
 
-export function renderAdminScreen(appElement: HTMLElement, tournamentData: any, MY_USER_ID: string) {
+
+/**
+ * トーナメント管理画面を描画する
+ */
+export function renderAdminScreen(appElement: HTMLElement, tournamentData: any, myUserId: string | null): void {
     if (!tournamentData) {
         render(appElement, `<p class="text-red-500">Tournament data not found.</p>`);
         return;
     }
-    if (MY_USER_ID !== tournamentData.owner_id) {
+    if (myUserId !== tournamentData.owner_id) {
         render(appElement, `<div class="text-center text-red-500 font-bold">アクセス権がありません。</div>`);
         return;
     }
     
     let actionButtonHTML = '';
     if (tournamentData.state === 'reception') {
-        actionButtonHTML = `
-            <div class="mt-8 border-t border-gray-600 pt-6">
-                <h3 class="text-lg font-semibold mb-2">トーナメントを開始する</h3>
-                <p class="text-sm text-gray-400 mb-4">参加者を確定し、対戦をオープンします。この操作は元に戻せません。</p>
-                <button class="w-full px-4 py-2 bg-green-600 hover:bg-green-700 rounded text-white font-bold" onclick="window.router.openTournament()">
-                    トーナメントをオープンする
-                </button>
-            </div>
-        `;
-    } else if (tournamentData.state === 'open') {
-         actionButtonHTML = `<div class="mt-8 text-center text-green-400 font-bold">トーナメントはオープン中です。</div>`;
+        actionButtonHTML = `<div class="mt-8 border-t border-gray-600 pt-6"><h3 class="text-lg font-semibold mb-2">トーナメントを開始する</h3><p class="text-sm text-gray-400 mb-4">参加者を確定し、対戦をオープンします。</p><button class="w-full px-4 py-2 bg-green-600 hover:bg-green-700 rounded text-white font-bold" onclick="window.router.openTournament()">トーナメントをオープンする</button></div>`;
+    } else if (tournamentData.state === 'open' || tournamentData.state === 'in_progress') {
+         actionButtonHTML = `<div class="mt-8 text-center text-green-400 font-bold">トーナメントは進行中です。</div>`;
     }
 
     const contentHTML = `
@@ -168,19 +157,17 @@ export function renderAdminScreen(appElement: HTMLElement, tournamentData: any, 
             <form onsubmit="window.router.handleAdminFormSubmit(event)">
                 <div class="mb-4">
                     <label for="name" class="block text-sm font-medium text-gray-300 mb-1">トーナメント名</label>
-                    <input type="text" id="name" name="name" value="${tournamentData.name}" class="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                    <input type="text" id="name" name="name" value="${tournamentData.name}" class="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2">
                 </div>
                 <div class="mb-4">
                     <label for="description" class="block text-sm font-medium text-gray-300 mb-1">説明</label>
-                    <textarea id="description" name="description" rows="3" class="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">${tournamentData.description}</textarea>
+                    <textarea id="description" name="description" rows="3" class="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2">${tournamentData.description}</textarea>
                 </div>
                 <div class="mb-6">
                     <label for="max_participants" class="block text-sm font-medium text-gray-300 mb-1">最大参加人数</label>
-                    <input type="number" id="max_participants" name="max_participants" value="${tournamentData.max_participants}" class="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                    <input type="number" id="max_participants" name="max_participants" value="${tournamentData.max_participants}" class="w-full bg-gray-700 border border-gray-600 rounded px-3 py-2">
                 </div>
-                <button type="submit" class="w-full px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded text-white font-bold">
-                    変更を保存
-                </button>
+                <button type="submit" class="w-full px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded text-white font-bold">変更を保存</button>
             </form>
             ${actionButtonHTML}
         </div>


### PR DESCRIPTION
Tournamentの描画
[#62](https://github.com/QWERTOP18/FT_TRANSCENDENCE/issues/62)

一覧画面の描画

待機画面の描画

トーナメント画面の描画(チャンピオン、pending、battle）

トーナメント中は、左側に待機者リスト（画面）、右側にbattle者リスト（画面）を表示し、最後（いわゆる勝利者が一人になったら）は、左側に最後のリストと、右側にチャンピオン画面を表示するようにする！

敗北者は次以降のラウンドではreadyが押せないようにする！

上記の一応の実装をしました！
ただ、api関連で画面の描画確認まではできていないので、了承ください！
また、細かい微調整などもしました。

まだ、クラスを使うだとかディレクトリを綺麗にするのはできていません...