### PR TITLE
Refactor tournament service to include user context in tournament retrieval

### DIFF
--- a/gateway/src/controller/routes/tournament/GetTournamentsRoute.ts
+++ b/gateway/src/controller/routes/tournament/GetTournamentsRoute.ts
@@ -39,7 +39,7 @@ export default function GetTournaments(fastify: FastifyInstance) {
     },
     async (request: FastifyRequest, reply: FastifyReply) => {
       try {
-        const tournaments = await tournamentService.getTournaments();
+        const tournaments = await tournamentService.getTournaments(request);
         return tournaments;
       } catch (error) {
         handleServiceError(error, reply, "Failed to fetch tournaments");

--- a/gateway/src/controller/schemas/TournamentSchema.ts
+++ b/gateway/src/controller/schemas/TournamentSchema.ts
@@ -30,7 +30,10 @@ export function TournamentSchema(options?: ObjectOptions) {
       description: Type.Optional(
         Type.String({ description: "トーナメントの説明" })
       ),
-      rule: TournamentRuleSchema({ description: "トーナメントのルール", default: "simple" }),
+      rule: TournamentRuleSchema({
+        description: "トーナメントのルール",
+        default: "simple",
+      }),
       state: TournamentStatusSchema(),
       participants: Type.Array(ParticipantIdSchema(), {
         description: "参加者リスト",
@@ -38,6 +41,15 @@ export function TournamentSchema(options?: ObjectOptions) {
       histories: Type.Array(HistoryIdSchema(), {
         description: "トーナメントの履歴",
       }),
+      is_participating: Type.Optional(
+        Type.Boolean({ description: "現在のユーザーが参加しているかどうか" })
+      ),
+      is_owner: Type.Optional(
+        Type.Boolean({
+          description: "現在のユーザーがオーナーかどうか",
+          default: false,
+        })
+      ),
     },
     { description: "トーナメント", ...options }
   );
@@ -59,9 +71,11 @@ export function TournamentStatusSchema(options?: SchemaOptions) {
 }
 
 // トーナメントルール
-export type TournamentRuleSchema = Static<ReturnType<typeof TournamentRuleSchema>>
+export type TournamentRuleSchema = Static<
+  ReturnType<typeof TournamentRuleSchema>
+>;
 export function TournamentRuleSchema(options?: SchemaOptions) {
-	return Type.String({ description: "トーナメントのルール", ...options })
+  return Type.String({ description: "トーナメントのルール", ...options });
 }
 
 // トーナメントID


### PR DESCRIPTION
- Updated `getTournaments` and `getTournament` methods to accept a request parameter, allowing for user-specific data (is_participating and is_owner) to be included in the response.
- Enhanced `TournamentSchema` to add optional fields for user participation and ownership status.
- Improved error handling when fetching participant data for tournaments.